### PR TITLE
Develop funk - UTF16 to UTF8

### DIFF
--- a/src/main/java/de/mediathekview/mlib/filmlisten/writer/FilmlistOldFormatWriter.java
+++ b/src/main/java/de/mediathekview/mlib/filmlisten/writer/FilmlistOldFormatWriter.java
@@ -9,9 +9,11 @@ import de.mediathekview.mlib.tool.VersionReader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.BufferedWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
@@ -43,7 +45,13 @@ public class FilmlistOldFormatWriter extends AbstractFilmlistWriter {
 
     final Collection<String> linesToWrite = Arrays.asList(filmlistAsFakeJson.split(LINE_BREAK));
     try {
-      Files.write(aSavePath, linesToWrite, StandardCharsets.UTF_8);
+      // https://stackoverflow.com/questions/26268132/all-inclusive-charset-to-avoid-java-nio-charset-malformedinputexception-input
+      //Files.write(aSavePath, linesToWrite, StandardCharsets.UTF_8);
+      BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(aSavePath.toFile()),StandardCharsets.UTF_8),512000);
+      for (String s : linesToWrite) 
+        bw.write(s);
+      bw.flush();
+      bw.close();
     } catch (final IOException ioException) {
       LOG.debug("Something went wrong on writing the film list.", ioException);
       publishMessage(LibMessages.FILMLIST_WRITE_ERROR, aSavePath.toAbsolutePath().toString());

--- a/src/main/java/de/mediathekview/mlib/filmlisten/writer/FilmlistOldFormatWriter.java
+++ b/src/main/java/de/mediathekview/mlib/filmlisten/writer/FilmlistOldFormatWriter.java
@@ -45,9 +45,7 @@ public class FilmlistOldFormatWriter extends AbstractFilmlistWriter {
 
     final Collection<String> linesToWrite = Arrays.asList(filmlistAsFakeJson.split(LINE_BREAK));
     try {
-      // https://stackoverflow.com/questions/26268132/all-inclusive-charset-to-avoid-java-nio-charset-malformedinputexception-input
-      //Files.write(aSavePath, linesToWrite, StandardCharsets.UTF_8);
-      BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(aSavePath.toFile()),StandardCharsets.UTF_8),512000);
+      final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(aSavePath.toFile()),StandardCharsets.UTF_8),512000);
       for (String s : linesToWrite) 
         bw.write(s);
       bw.flush();

--- a/src/main/java/de/mediathekview/mlib/filmlisten/writer/FilmlistWriter.java
+++ b/src/main/java/de/mediathekview/mlib/filmlisten/writer/FilmlistWriter.java
@@ -34,11 +34,12 @@ public class FilmlistWriter extends AbstractFilmlistWriter
     public boolean write(final Filmlist aFilmlist, final Path aSavePath)
     {
         final Gson gson = new Gson();
-        // https://stackoverflow.com/questions/26268132/all-inclusive-charset-to-avoid-java-nio-charset-malformedinputexception-input
-        //try (BufferedWriter fileWriter = Files.newBufferedWriter(aSavePath, StandardCharsets.UTF_8))
-        try (BufferedWriter fileWriter = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(aSavePath.toFile()),StandardCharsets.UTF_8),512000))
+        try
         {
-            gson.toJson(aFilmlist, fileWriter);
+           final BufferedWriter fileWriter = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(aSavePath.toFile()),StandardCharsets.UTF_8),512000);
+           gson.toJson(aFilmlist, fileWriter);
+           fileWriter.flush();
+           fileWriter.close();
         }
         catch (final IOException ioException)
         {

--- a/src/main/java/de/mediathekview/mlib/filmlisten/writer/FilmlistWriter.java
+++ b/src/main/java/de/mediathekview/mlib/filmlisten/writer/FilmlistWriter.java
@@ -1,9 +1,10 @@
 package de.mediathekview.mlib.filmlisten.writer;
 
 import java.io.BufferedWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.apache.logging.log4j.LogManager;
@@ -33,7 +34,9 @@ public class FilmlistWriter extends AbstractFilmlistWriter
     public boolean write(final Filmlist aFilmlist, final Path aSavePath)
     {
         final Gson gson = new Gson();
-        try (BufferedWriter fileWriter = Files.newBufferedWriter(aSavePath, StandardCharsets.UTF_8))
+        // https://stackoverflow.com/questions/26268132/all-inclusive-charset-to-avoid-java-nio-charset-malformedinputexception-input
+        //try (BufferedWriter fileWriter = Files.newBufferedWriter(aSavePath, StandardCharsets.UTF_8))
+        try (BufferedWriter fileWriter = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(aSavePath.toFile()),StandardCharsets.UTF_8),512000))
         {
             gson.toJson(aFilmlist, fileWriter);
         }


### PR DESCRIPTION
Java NIO wirft eine Exception wenn eine Übersetzung von UTF16 nach UTF8 nicht geht.
Der normale Writter ersetzt einfach unbekannte Zeichen nach "?"
Beim Sender FUNK sind anscheinend irgendwelche Sonderzeichen (smilies?) in der Beschreibung / Titel.

Siehe auch hier
https://stackoverflow.com/questions/26268132/all-inclusive-charset-to-avoid-java-nio-charset-malformedinputexception-input

Die Änderung sollte unproblematisch sein...nur etwas mehr code...